### PR TITLE
Added /recipepriner fromJei command for more compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,16 +130,20 @@ repositories {
         name = "MelanX Maven"
         url = "https://maven.melanx.de/"
     }
+    maven {
+        url = "https://www.cursemaven.com"
+    }
 }
 
 dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
-    runtimeOnly fg.deobf("mezz.jei:jei-1.16.2:${jei_version}")
+    compile fg.deobf("mezz.jei:jei-1.16.2:${jei_version}")
 
     compile fg.deobf("vazkii.botania:Botania:${botania_version}")
     runtime fg.deobf("top.theillusivec4.curios:curios-forge:${mc_version}-${curios_version}")
     compile fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
     compile fg.deobf("io.github.noeppi_noeppi.mods:LibX:${mc_version}-${libx_version}")
+    runtime fg.deobf("curse.maven:create-328085:3167531")
 }
 
 private static String getVersion(String group, String artifact, String baseVersion) {

--- a/build.gradle
+++ b/build.gradle
@@ -130,9 +130,6 @@ repositories {
         name = "MelanX Maven"
         url = "https://maven.melanx.de/"
     }
-    maven {
-        url = "https://www.cursemaven.com"
-    }
 }
 
 dependencies {
@@ -143,7 +140,6 @@ dependencies {
     runtime fg.deobf("top.theillusivec4.curios:curios-forge:${mc_version}-${curios_version}")
     compile fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
     compile fg.deobf("io.github.noeppi_noeppi.mods:LibX:${mc_version}-${libx_version}")
-    runtime fg.deobf("curse.maven:create-328085:3167531")
 }
 
 private static String getVersion(String group, String artifact, String baseVersion) {

--- a/src/main/java/de/melanx/recipeprinter/commands/JeiCommand.java
+++ b/src/main/java/de/melanx/recipeprinter/commands/JeiCommand.java
@@ -1,0 +1,56 @@
+package de.melanx.recipeprinter.commands;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import de.melanx.recipeprinter.Config;
+import de.melanx.recipeprinter.RecipePrinter;
+import de.melanx.recipeprinter.jei.PrinterJEI;
+import de.melanx.recipeprinter.util.ImageHelper;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.gui.recipes.RecipeLayout;
+import net.minecraft.command.CommandSource;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.util.ResourceLocation;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static de.melanx.recipeprinter.jei.PrinterJEI.REG;
+
+public class JeiCommand implements Command<CommandSource> {
+	@Override
+	public int run(CommandContext<CommandSource> context) {
+		if (PrinterJEI.REG == null)
+			return 0;
+		RecipeSelector sel = context.getArgument("recipes", RecipeSelector.class);
+		RecipeManager rm = context.getSource().getServer().getRecipeManager();
+		List<ResourceLocation> recipes = sel.getRecipes(rm);
+		ImmutableList<IRecipeCategory<?>> categories = REG.getRecipeCategories();
+
+		for (ResourceLocation rl : recipes) {
+			rm.getRecipe(rl).ifPresent(iRecipe -> categories.stream().filter(iRecipeCategory -> iRecipeCategory.getRecipeClass().isAssignableFrom(iRecipe.getClass())).forEach(iRecipeCategory -> {
+				RecipePrinter.getInstance().logger.debug("Printing " + iRecipeCategory + " " + iRecipe);
+				Path path = context.getSource().getServer().getDataDirectory().toPath().resolve(RecipePrinter.getInstance().modid).resolve("recipes").resolve(rl.getNamespace()).resolve(rl.getPath().replace('/', File.separatorChar) + ".png");
+				if (!Files.exists(path.getParent())) {
+					try {
+						Files.createDirectories(path.getParent());
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				}
+
+				IRecipeCategory<IRecipe<?>> category = (IRecipeCategory<IRecipe<?>>) iRecipeCategory;
+				RecipeLayout<?> layout = RecipeLayout.create(-1, category, iRecipe, null, REG.getJeiHelpers().getModIdHelper(), 0, 0);
+				if (layout != null)
+					ImageHelper.addRenderJob(category.getBackground().getWidth(), category.getBackground().getHeight(), Config.scale.get() * 2., (matrixStack, buffer) -> layout.drawRecipe(matrixStack, 0, 0), path, true);
+			}));
+		}
+
+		return 0;
+	}
+}

--- a/src/main/java/de/melanx/recipeprinter/commands/RecipePrinterCommands.java
+++ b/src/main/java/de/melanx/recipeprinter/commands/RecipePrinterCommands.java
@@ -1,10 +1,13 @@
 package de.melanx.recipeprinter.commands;
 
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import de.melanx.recipeprinter.RecipePrinter;
 import de.melanx.recipeprinter.util.Util;
+import net.minecraft.command.CommandSource;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.fml.ModList;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -17,12 +20,18 @@ import static net.minecraft.command.Commands.literal;
 public class RecipePrinterCommands {
 
     public static void register(RegisterCommandsEvent event) {
-        event.getDispatcher().register(literal(RecipePrinter.getInstance().modid).then(
-                literal("recipe").then(argument("recipes", recipeSelector()).executes(new RecipeCommand()))
+        LiteralArgumentBuilder<CommandSource> builer = literal(RecipePrinter.getInstance().modid).then(
+            literal("recipe").then(argument("recipes", recipeSelector()).executes(new RecipeCommand()))
         ).then(
-                literal("itemgroup").then(argument("group",
-                        resourceLocation(() -> Arrays.stream(ItemGroup.GROUPS).filter(Util::isNormalItemGroup).map(group -> new ResourceLocation(group.getPath())).collect(Collectors.toList())))
+            literal("itemgroup").then(argument("group",
+                resourceLocation(() -> Arrays.stream(ItemGroup.GROUPS).filter(Util::isNormalItemGroup).map(group -> new ResourceLocation(group.getPath())).collect(Collectors.toList())))
                 .executes(new ItemGroupCommand()))
-        ));
+        );
+
+        if (ModList.get().isLoaded("jei")) {
+            builer = builer.then(literal("fromJei").then(argument("recipes", recipeSelector()).executes(new JeiCommand())));
+        }
+
+        event.getDispatcher().register(builer);
     }
 }

--- a/src/main/java/de/melanx/recipeprinter/jei/PrinterJEI.java
+++ b/src/main/java/de/melanx/recipeprinter/jei/PrinterJEI.java
@@ -1,0 +1,29 @@
+package de.melanx.recipeprinter.jei;
+
+import de.melanx.recipeprinter.RecipePrinter;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.MethodsReturnNonnullByDefault;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.load.registration.RecipeCategoryRegistration;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+@JeiPlugin
+@MethodsReturnNonnullByDefault
+public class PrinterJEI implements IModPlugin {
+	@Nullable
+	public static RecipeCategoryRegistration REG = null;
+
+	@Override
+	public ResourceLocation getPluginUid() {
+		return new ResourceLocation(RecipePrinter.getInstance().modid, "fake_plugin");
+	}
+
+	@Override
+	public void registerCategories(IRecipeCategoryRegistration registration) {
+		if (registration instanceof RecipeCategoryRegistration)
+			REG = ((RecipeCategoryRegistration) registration);
+	}
+}

--- a/src/main/java/de/melanx/recipeprinter/util/ImageHelper.java
+++ b/src/main/java/de/melanx/recipeprinter/util/ImageHelper.java
@@ -2,6 +2,7 @@ package de.melanx.recipeprinter.util;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
+import de.melanx.recipeprinter.RecipePrinter;
 import io.github.noeppi_noeppi.libx.render.RenderHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.FogRenderer;
@@ -100,7 +101,7 @@ public class ImageHelper {
         try {
             img.write(imagePath);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            RecipePrinter.getInstance().logger.error("Could not print recipe: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
This is an experimental feature, as our wiki authors use it more i'll upload some fixes to this pr.

What does it do?
This PR adds the command option /recipeprinter fromJei which allows to print recipes from how they are rendered in JEI instead of the recipe printer specific code. This command is only loaded when JEI is present.

Why is this helpful?
Very few mods have specific recipe printer compat. Yet generating neat screenshots for wiki articles is appreciated. Instead of writing support for mods like Create specifically, this gives the option of basic support for practically every mod.